### PR TITLE
Change overflow to auto instead of always including scrollbars

### DIFF
--- a/_sass/code.scss
+++ b/_sass/code.scss
@@ -6,7 +6,7 @@ pre, code {
   -moz-border-radius: 3px;
   border-radius: 3px;
   font-size: 15px;
-  overflow: scroll;
+  overflow: auto;
 
   margin: 0px;
 }


### PR DESCRIPTION
before and after screenshots:
<img width="760" alt="screen shot 2016-08-03 at 3 02 47 pm" src="https://cloud.githubusercontent.com/assets/730388/17378330/7efb077a-598b-11e6-901e-6c35d9d590ef.png">
