### PR TITLE
multi-line link style

### DIFF
--- a/css/site.scss
+++ b/css/site.scss
@@ -280,17 +280,12 @@ p {
   a {
     color: #444;
     position: relative;
-    text-decoration: none;    
+    border-bottom-width: 1px; // text-decoration would be easier, but not supported by Chrome:
+    border-bottom-style: dotted; // http://caniuse.com/#feat=text-decoration
+    -webkit-box-decoration-break: clone;
+    -o-box-decoration-break: clone;
+    box-decoration-break: clone;
   }
-  a:after{
-     position: absolute;
-     left: 0;
-     bottom: 0;
-     content: '';
-     width: 100%;
-     border-bottom-width: 1px;
-     border-bottom-style: dotted;
-  }    
 }
 
 @mixin page-content() {


### PR DESCRIPTION
Fix #133 ... though I am not confident I understand the original motivation of the `a:after`.
Looks good to me on both FF and Chrome.